### PR TITLE
*: Fix compile error under macos

### DIFF
--- a/3rdlibs/sdl2/CMakeLists.txt
+++ b/3rdlibs/sdl2/CMakeLists.txt
@@ -1,7 +1,7 @@
-message("find package: SDL2 ...")
-find_package(SDL2 QUIET)
+message(STATUS "find package: SDL2 ...")
 
 # check SDL
+find_package(SDL2 QUIET)
 if (SDL2_FOUND)
     if (NOT EXISTS "${SDL2_INCLUDE_DIRS}/SDL.h")
         set(SDL2_FOUND OFF)
@@ -26,7 +26,7 @@ if (NOT SDL2_FOUND)
             message("SDL2 information:")
             message("\tinclude dir: ${SDL2_INCLUDE_DIRS}")
             message("\tSDL libs: ${SDL2_LIBRARIES}")
-            if (WIN32)
+            if (WIN32 OR APPLE)
                 add_library(SDL2 INTERFACE IMPORTED GLOBAL)
                 target_link_libraries(SDL2 INTERFACE SDL2::SDL2 SDL2::SDL2main)
             else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(NICKEL_COPYDLL "auto copy needed dll to output dir" OFF)
 include(cmake/copy_dll.cmake)
 
+set (CMAKE_CXX_STANDARD 20)
+
 add_subdirectory(3rdlibs)
 add_subdirectory(nickel)
 add_subdirectory(plugins)

--- a/editor/src/content_browser.cpp
+++ b/editor/src/content_browser.cpp
@@ -168,6 +168,7 @@ void ContentBrowserWindow::showOneIcon(
                         break;
                     case nickel::FileType::Timer:
                     case nickel::FileType::FileTypeCount:
+                    case nickel::FileType::Meta:
                     case nickel::FileType::Unknown:
                         break;
                 }

--- a/nickel/include/core/gogl.hpp
+++ b/nickel/include/core/gogl.hpp
@@ -600,7 +600,10 @@ struct Sampler final {
 
         bool operator==(const Wrapper& o) const {
             return s == o.s && r == o.r && t == o.t &&
-                   borderColor == o.borderColor;
+                   borderColor[0] == o.borderColor[0] &&
+                   borderColor[1] == o.borderColor[1] &&
+                   borderColor[2] == o.borderColor[2] &&
+                   borderColor[3] == o.borderColor[3];
         }
 
         bool operator!=(const Wrapper& o) const { return !(*this == o); }

--- a/nickel/include/core/manager.hpp
+++ b/nickel/include/core/manager.hpp
@@ -200,7 +200,16 @@ protected:
     std::unordered_map<AssetHandle, AssetStoreType, typename AssetHandle::Hash,
                        typename AssetHandle::Eq>
         datas_;
-    std::unordered_map<std::filesystem::path, AssetHandle> pathHandleMap_;
+
+    class PathHash {
+    public:
+        size_t operator()(const std::filesystem::path& p) const {
+            return std::hash<std::string>()(p.string());
+        }
+    };
+
+    std::unordered_map<std::filesystem::path, AssetHandle, PathHash>
+        pathHandleMap_;
 };
 
 }  // namespace nickel


### PR DESCRIPTION
Fix the following errors:

* Fix the cmake error under macos in the previous code
```
>  cmake -S . -B cmake-build
-- The C compiler identification is AppleClang 15.0.0.15000100
-- The CXX compiler identification is AppleClang 15.0.0.15000100
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
find package: SDL2 ...
cmake find SDL2 failed! use pkg-config...
pkg-config found OK
pkg-config found SDL2
SDL2 information:
        include dir: /opt/homebrew/include;/opt/homebrew/include/SDL2
        SDL libs: SDL2
CMake Error at 3rdlibs/sdl2/CMakeLists.txt:34 (target_include_directories):
  target_include_directories called with invalid arguments
```

* `std::filesystem::path` does not have default hash operator to be the key of `unordered_map`. I've define a functor class for it
* Fix that `Sampler::Wrapper::operator==` compare float array in an incorrect way